### PR TITLE
Blue instead of Violette

### DIFF
--- a/src/main/java/ohm/softa/a05/model/PlantColor.java
+++ b/src/main/java/ohm/softa/a05/model/PlantColor.java
@@ -8,6 +8,6 @@ public enum PlantColor {
 	GREEN,
 	YELLOW,
 	RED,
-	VIOLETTE,
+	BLUE,
 	ORANGE
 }


### PR DESCRIPTION
We should use Blue (described in the diagram). Therefore "BLUE" is the correct colour instead of "VIOLETTE" for the file PlantColour.java in the branch musterloesung.